### PR TITLE
fix: invalid token raises server error

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,9 +41,14 @@ def verify_jwt():
     """
     Check that a token is valid, if it is provided.
     Token is optional in this route - authentication only.
+    If invalid token received, returns JSON:
+    { "errors": "Invalid token" }
     """
 
-    verify_jwt_in_request(locations=['headers', 'cookies'], optional=True)
+    try:
+        verify_jwt_in_request(locations=['headers', 'cookies'], optional=True)
+    except Exception:
+        return jsonify(errors="Invalid token")
 
 @app.post("/signup")
 def signup():


### PR DESCRIPTION
Updated validate jwt before_request so it now returns JSON message of invalid token being received, and no longer crashes the server

Resolves #28 